### PR TITLE
Replace local methodology PDF links with external URLs

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -14,7 +14,7 @@
         "about": "About",
         "about_platform": "About the platform",
         "about_indicators": "About the indicators",
-        "indicator_about_pdf_url": "/files/HTI platform Methodology documentation - Release v4.0_Jan2025.pdf",
+        "indicator_about_pdf_url": "https://flowminder.org/methodology-documentation-eng",
         "data_quality_status": "Outliers and Missing Data",
         "dqs_error_message": "DQS currently unavailable - please contact Flowminder.",
         "explore": "Explore",
@@ -37,7 +37,7 @@
         "info": "Method Overview",
         "flowgeek_text": "For more information please visit ",
         "read_more": "Read more",
-        "read_more_link": "/files/HTI platform Methodology documentation - Release v4.0_Jan2025.pdf"
+        "read_more_link": "https://flowminder.org/methodology-documentation-eng"
     },
     "dashboard": {
         "dashboard": "Haiti Mobility Data Dashboard",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -14,7 +14,7 @@
         "about": "À propos",
         "about_platform": "À propos de la plateforme",
         "about_indicators": "À propos des indicateurs",
-        "indicator_about_pdf_url": "/files/HTI plateforme documentation méthodologie - Sortie v4.0_Janvier2025_FR.pdf",
+        "indicator_about_pdf_url": "https://flowminder.org/methodologie-documentation-fr",
         "data_quality_status": "Valeurs Aberrantes et Données Manquantes",
         "dqs_error_message": "DQS actuellement indisponible - veuillez contacter Flowminder.",
         "explore": "Explorer",
@@ -37,7 +37,7 @@
         "info": "Aperçu de la méthode",
         "flowgeek_text": "Pour plus d'informations, s'il vous plaît visitez ",
         "read_more": "En savoir plus",
-        "read_more_link": "/files/HTI plateforme documentation méthodologie - Sortie v4.0_Janvier2025_FR.pdf"
+        "read_more_link": "https://flowminder.org/methodologie-documentation-fr"
     },
     "dashboard": {
         "dashboard": "Haiti Mobility Data Dashboard",

--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -57,9 +57,9 @@ const Banner = () => {
                             <Link to="/about">{t("menu.about_platform")}</Link>
                         </li>
                         <li>
-                            <Link to={t("menu.indicator_about_pdf_url")} rel="noreferrer" target="_blank">
-                                {`${t("menu.about_indicators")} [pdf]`}
-                            </Link>
+                            <a href={t("menu.indicator_about_pdf_url")} rel="noreferrer" target="_blank">
+                                {t("menu.about_indicators")}
+                            </a>
                         </li>
                         <li>
                             <DQSLink />


### PR DESCRIPTION
## Summary
- Updates `menu.indicator_about_pdf_url` and `sidebar.read_more_link` in EN and FR translation files to point to external flowminder.org pages instead of local `/files/` PDFs
- Switches the "About the indicators" menu link in `Banner.js` from React Router `<Link>` to a plain `<a>` tag (React Router v6 does not support external URLs)
- Removes the `[pdf]` label suffix from the menu item

## Test plan
- [ ] "About the indicators" menu link opens `https://flowminder.org/methodology-documentation-eng` in a new tab (EN)
- [ ] Same link opens `https://flowminder.org/methodologie-documentation-fr` when in French
- [ ] Sidebar "Read more" link works correctly in both languages
- [ ] Other menu links (Terms, Privacy, About the platform) are unaffected