### PR TITLE
Update methodology documentation URLs

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -14,7 +14,7 @@
         "about": "About",
         "about_platform": "About the platform",
         "about_indicators": "About the indicators",
-        "indicator_about_pdf_url": "https://flowminder.org/methodology-documentation-eng",
+        "indicator_about_pdf_url": "https://www.flowminder.org/haiti-methodology-documentation-eng",
         "data_quality_status": "Outliers and Missing Data",
         "dqs_error_message": "DQS currently unavailable - please contact Flowminder.",
         "explore": "Explore",
@@ -37,7 +37,7 @@
         "info": "Method Overview",
         "flowgeek_text": "For more information please visit ",
         "read_more": "Read more",
-        "read_more_link": "https://flowminder.org/methodology-documentation-eng"
+        "read_more_link": "https://www.flowminder.org/haiti-methodology-documentation-eng"
     },
     "dashboard": {
         "dashboard": "Haiti Mobility Data Dashboard",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -14,7 +14,7 @@
         "about": "À propos",
         "about_platform": "À propos de la plateforme",
         "about_indicators": "À propos des indicateurs",
-        "indicator_about_pdf_url": "https://flowminder.org/methodologie-documentation-fr",
+        "indicator_about_pdf_url": "https://www.flowminder.org/haiti-methodologie-documentation-fr",
         "data_quality_status": "Valeurs Aberrantes et Données Manquantes",
         "dqs_error_message": "DQS actuellement indisponible - veuillez contacter Flowminder.",
         "explore": "Explorer",
@@ -37,7 +37,7 @@
         "info": "Aperçu de la méthode",
         "flowgeek_text": "Pour plus d'informations, s'il vous plaît visitez ",
         "read_more": "En savoir plus",
-        "read_more_link": "https://flowminder.org/methodologie-documentation-fr"
+        "read_more_link": "https://www.flowminder.org/haiti-methodologie-documentation-fr"
     },
     "dashboard": {
         "dashboard": "Haiti Mobility Data Dashboard",


### PR DESCRIPTION
## Summary
- Corrects the methodology documentation URLs set in the previous PR to the right paths:
  - EN: `https://www.flowminder.org/haiti-methodology-documentation-eng`
  - FR: `https://www.flowminder.org/haiti-methodologie-documentation-fr`

Applies to both `menu.indicator_about_pdf_url` and `sidebar.read_more_link` in EN and FR translation files.