### PR TITLE
Fix arc widths for values above an open-ended top bin

### DIFF
--- a/src/pages/Dashboard/views/MapView/MapView.js
+++ b/src/pages/Dashboard/views/MapView/MapView.js
@@ -158,7 +158,7 @@ const MapView = ({
         // indicator specifies bins
         if (indicator?.bins) {
             indicator_bins = indicator.bins.slice()
-            indicator_bins.sort((a, b) => (a.min || -Infinity) - (b.min || -Infinity))
+            indicator_bins.sort((a, b) => (a.min ?? -Infinity) - (b.min ?? -Infinity))
             // calculate range, bins & values when it's not set in the indicator
         } else {
             numArcWidthSteps = Math.abs(MAX_ARC_WIDTH - MIN_ARC_WIDTH)
@@ -182,13 +182,12 @@ const MapView = ({
             getTilt: f => -90,
             getWidth: f => {
                 if (indicator_bins) {
-                    let width
-                    indicator_bins.forEach(bin => {
-                        if ((bin.min || -Infinity) <= f.count && bin.max > f.count) {
-                            width = bin.width
-                            return
-                        }
+                    const matchedBin = indicator_bins.find(bin => {
+                        const binMin = bin.min ?? -Infinity
+                        const binMax = bin.max ?? Infinity
+                        return binMin <= f.count && binMax > f.count
                     })
+                    let width = matchedBin?.width
                     // use absolute percentage in pixels if given
                     if (!isNaN(Number(width))) {
                         return width


### PR DESCRIPTION
## Summary
Latent bug in `MapView.js:makeArcLayer` where a bin with `max: null` (open-ended top, e.g. `{min: 100, max: null, width: "30%"}`) never matched any value, because `null > f.count` evaluates to `0 > f.count` in JavaScript. With no bin matching, the arc width ended up NaN and rendered at a default-ish thin width — so a flow with value 199% looked the same thickness as a flow with value 0%.

Same `|| -Infinity` foot-gun also applied on the sort comparator, which would misplace a bin with `min: 0` (treated as falsy).

This wasn't visible before because the only indicator using open-ended bins (`*.abnormality`) clamps display via `min_value: -6, max_value: 6` so values rarely cross that boundary. Hit it once the new `pctchange` bins (PR #30 in flowkit-ui-backend) started classifying unclamped real values up to ~200%.

## Changes
- Replace `bin.min || -Infinity` with `bin.min ?? -Infinity` in both the sort comparator and the lookup.
- Add `bin.max ?? Infinity` in the lookup to handle the open-ended top bin.
- Refactor the lookup to `.find()` so "first matching bin wins" is explicit; the old `forEach` + `return` was a no-op (last match would silently win).

Reported by Jake on Haiti dev where a 199.47% flow rendered at the same thickness as a 0% flow.

## Test plan
- [ ] On dev, hover over a few flows on \`relocations.relocations_pctchangewithref\` covering small (\<25%), medium (25-100%), and large (>100%) magnitudes; arrow widths should now match the bin tiers.
- [ ] Same on \`movements.travellers_pctchangewithref\`.
- [ ] Abnormality indicators (already used bins) still render correctly.