### PR TITLE
CI hardening: disable DLC, make codecov upload non-blocking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,11 @@ commands:
         type: string
     steps:
       - run:
-          name: Upload codecov
+          name: Upload codecov (non-blocking)
           command: |
+            # Coverage upload is observability, not a release gate. Don't fail
+            # the deploy if keybase/codecov/uploader.codecov.io has a blip.
+            set +e
             curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
@@ -18,6 +21,7 @@ commands:
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov
             ./codecov <<parameters.test>>
+            exit 0
 defaults:
   - &autodeploy
     filters:
@@ -31,7 +35,10 @@ jobs:
     build:
     machine:
       image: default
-      docker_layer_caching: true
+      # DLC turned off: persistent cache corruption was blocking deploys with
+      # "failed to compute cache key: parent snapshot ... does not exist".
+      # Matches the same setting in flowminder-gcp-mobility-dashboard.
+      docker_layer_caching: false
     working_directory: /tmp/flowkit-ui
     steps:
       - checkout


### PR DESCRIPTION
## Summary
Two flaky-CI fixes that both blocked PR #66's auto-deploy to dev today.

### 1. Docker Layer Caching off
On the rerun of PR #66's build, docker build failed with:
\`\`\`
ERROR: failed to build: failed to solve: failed to compute cache key:
parent snapshot sha256:29df493... does not exist: not found
\`\`\`
Classic DLC corruption — the cache index references a layer the CircleCI runner has evicted. Builds get marginally slower with DLC off but become reliable. Matches the same setting in \`flowminder-gcp-mobility-dashboard\` which has a comment explicitly calling out the same issue.

### 2. Codecov upload non-blocking
First attempt of PR #66 failed at the codecov step, which then skipped the downstream \`update-mob-dashtag\` job and blocked the deploy. The codecov command does six external network calls (keybase.io PGP key fetch, three downloads from uploader.codecov.io, PGP verify, SHA256 verify) before the actual upload — any failing kills the step. Coverage upload is observability, not a release gate; should never block a deploy.

Wrap the script in \`set +e\` and \`exit 0\` so transient keybase/codecov blips log but don't fail the pipeline.

## Test plan
- [ ] Merge and watch the auto-deploy chain run cleanly.
- [ ] Confirm in CircleCI that the codecov step runs (and either succeeds or shows the failure in logs without failing the job).