### PR TITLE
Fix slider values shape — selectedTimeEntity was double-wrapped

### DIFF
--- a/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
+++ b/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
@@ -169,7 +169,7 @@ const CurrentTimeUnitSlider = () => {
         <div className={styles.CurrentTimeUnitSlider} data-testid="CurrentTimeUnitSlider">
             {currentAvailableTimeRange && selectedTimeRangeForCurrentData && (
                 <FMSlider
-                    values={[selectedTimeEntity]}
+                    values={selectedTimeEntity}
                     outerLabelsOnly={true}
                     step={1}
                     min={selectedTimeRangeForCurrentData[0]}


### PR DESCRIPTION
## Summary
Pre-existing shape bug found while diagnosing why slider ticks/labels disappear when switching to certain indicators (most reliably reproduced on Residents → Abnormality, but the warning fires on every render for every indicator).

\`selectedTimeEntity\` is already an array \`[number]\` in redux — set that way by the local \`adjustSelectedTimeEntity\` effect and by react-range's own \`onChange\` (which passes \`number[]\`). The slider's \`values\` prop wrapped it again:

\`\`\`js
values={[selectedTimeEntity]}    // [[number]] — wrong shape
\`\`\`

react-range coerces the inner array to a string then a number, so most of the time the slider renders correctly. But when the inner value falls outside the new \`[min, max]\` during an indicator switch, react-range's strict check kicks in and logs:

\`\`\`
The \`values\` property is in conflict with the current \`step\`, \`min\`, and \`max\` properties.
\`\`\`

In that state, marks (ticks) and labels stop rendering. The track and thumb still appear. The bug only "fixes" itself when the category changes, because \`resetParameters\` (Dashboard.js:264) dispatches \`setSelectedTimeRangeForCurrentData(undefined)\` which resets everything — but indicator-only switches don't go through that path.

## Fix
\`\`\`js
values={selectedTimeEntity}
\`\`\`

One-character change (well, removing brackets). selectedTimeEntity is already the right shape.

## Test plan
- [ ] In dev, switch Residents → Abnormality and back to another Residents indicator several times — slider ticks and labels stay put.
- [ ] Drag the slider thumb — confirms onChange still works (no regression on the round trip).
- [ ] No more \`values is in conflict\` warnings in the console.