### PR TITLE
Fix slider tick positioning — stop remounting marks on every render

### DIFF
--- a/src/components/FMSlider/FMSlider.js
+++ b/src/components/FMSlider/FMSlider.js
@@ -57,9 +57,7 @@ const FMSlider = ({
                             <>
                                 {!cumulative && (
                                     <div ref={props.ref} className={styles.selectedInvisible}>
-                                        {children.map(c => {
-                                            return { ...c, key: Math.random() }
-                                        })}
+                                        {children.map((c, idx) => React.cloneElement(c, { key: idx }))}
                                     </div>
                                 )}
                                 {cumulative && (
@@ -76,9 +74,7 @@ const FMSlider = ({
                                             })
                                         }}
                                     >
-                                        {children.map(c => {
-                                            return { ...c, key: Math.random() }
-                                        })}
+                                        {children.map((c, idx) => React.cloneElement(c, { key: idx }))}
                                     </div>
                                 )}
                             </>
@@ -98,9 +94,7 @@ const FMSlider = ({
                                     })
                                 }}
                             >
-                                {children.map(c => {
-                                    return { ...c, key: Math.random() }
-                                })}
+                                {children.map((c, idx) => React.cloneElement(c, { key: idx }))}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary
Final piece of the slider bug puzzle. After PR #65 (labels useMemo deps) and PR #68 (values shape), the slider track and thumb worked but ticks and labels still didn't render. DOM inspection showed twelve \`SliderTick\` divs all positioned at \`left: -4999px\` to \`-3924px\` — about 5000 pixels off-screen to the left.

The cause was in \`FMSlider.js\`:

\`\`\`js
{children.map(c => {
    return { ...c, key: Math.random() }
})}
\`\`\`

Two problems:
1. \`{ ...c, key: ... }\` produces a plain object, not a proper React element (no \`React.createElement\` / \`cloneElement\` involved). React renders the shape but can't reconcile it correctly.
2. \`Math.random()\` gives every mark a new key on every render, so React unmounts and remounts every tick every cycle. react-range relies on stable element identity to measure the track and compute mark positions; with constant remounts it ends up writing absolute pixel offsets that send all marks off-screen.

The thumb is rendered via a separate \`renderThumb\` code path that doesn't touch \`children.map\`, which is why dragging still worked.

## Fix
Replace all three branches (\`selectedInvisible\`, \`selectedVisible\`, \`selected\`) with:

\`\`\`js
{children.map((c, idx) => React.cloneElement(c, { key: idx }))}
\`\`\`

\`React.cloneElement\` creates a proper element; \`idx\` is a stable key per position so React can reconcile without remounting.

## Test plan
- [ ] In dev, switch Residents → Abnormality. Ticks and labels appear and stay.
- [ ] Drag the slider thumb — onChange still fires, thumb moves smoothly.
- [ ] Inspect a \`SliderTick\` in DevTools — \`left\` should now be a sensible percentage or pixel value within the track, not negative thousands.