### PR TITLE
Fix slider mark ref propagation — remove Fragment wrapper in renderMark

### DIFF
--- a/src/components/FMSlider/FMSlider.js
+++ b/src/components/FMSlider/FMSlider.js
@@ -57,7 +57,7 @@ const FMSlider = ({
                             <>
                                 {!cumulative && (
                                     <div ref={props.ref} className={styles.selectedInvisible}>
-                                        {children.map((c, idx) => React.cloneElement(c, { key: idx }))}
+                                        {children}
                                     </div>
                                 )}
                                 {cumulative && (
@@ -74,7 +74,7 @@ const FMSlider = ({
                                             })
                                         }}
                                     >
-                                        {children.map((c, idx) => React.cloneElement(c, { key: idx }))}
+                                        {children}
                                     </div>
                                 )}
                             </>
@@ -94,7 +94,7 @@ const FMSlider = ({
                                     })
                                 }}
                             >
-                                {children.map((c, idx) => React.cloneElement(c, { key: idx }))}
+                                {children}
                             </div>
                         )}
                     </div>
@@ -110,41 +110,26 @@ const FMSlider = ({
                         </div>
                     </div>
                 )}
-                renderMark={({ props, index }) => (
-                    <>
-                        {!isRange && (
-                            <>
-                                {!cumulative && (
-                                    <div {...props} className={styles.SliderTick}>
-                                        <div className={styles.SliderLabel}>{getLabelForIndex(index)}</div>
-                                    </div>
-                                )}
-                                {cumulative && (
-                                    <div
-                                        {...props}
-                                        className={`${styles.SliderTick} ${
-                                            step * index + min <= values[0] ? styles.selected : ""
-                                        }`}
-                                    >
-                                        <div className={styles.SliderLabel}>{getLabelForIndex(index)}</div>
-                                    </div>
-                                )}
-                            </>
-                        )}
-                        {isRange && (
-                            <div
-                                {...props}
-                                className={`${styles.SliderTick} ${
-                                    step * index + min > values[0] && step * index + min <= values[1]
-                                        ? styles.selected
-                                        : ""
-                                }`}
-                            >
-                                <div className={styles.SliderLabel}>{getLabelForIndex(index)}</div>
-                            </div>
-                        )}
-                    </>
-                )}
+                renderMark={({ props, index }) => {
+                    // single-element renderMark so react-range's key/ref/style props
+                    // land on the outermost rendered div. wrapping in a Fragment
+                    // makes the Fragment keyless and breaks react-range's mark
+                    // measurement (markRefs[i].current stays null, fallback width=9999
+                    // sends positions off-screen to ~-5000px).
+                    const value = step * index + min
+                    let tickClass = styles.SliderTick
+                    if (!isRange && cumulative && value <= values[0]) {
+                        tickClass += ` ${styles.selected}`
+                    }
+                    if (isRange && value > values[0] && value <= values[1]) {
+                        tickClass += ` ${styles.selected}`
+                    }
+                    return (
+                        <div {...props} className={tickClass}>
+                            <div className={styles.SliderLabel}>{getLabelForIndex(index)}</div>
+                        </div>
+                    )
+                }}
             />
 
             {outputIsVisible && (


### PR DESCRIPTION
## Summary
The actual root cause of the off-screen slider ticks. Our \`renderMark\` returned a Fragment (\`<>...</>\`) wrapping a single div, so react-range's \`props\` (which contains \`key\`, \`ref\`, and inline positioning \`style\`) spread onto the inner div rather than the outermost rendered element. When \`calculateMarkOffsets\` runs, \`markRefs[i].current\` is null and the offset formula falls back to \`markWidth = markHeight = 9999\`:

\`\`\`js
left = (trackWidth / numOfMarks) * i + paddingLeft - markWidth / 2  // ≈ -4999
marginTop = -((markHeight - trackHeight) / 2)                       // ≈ -4997
\`\`\`

Exactly the values seen in the DOM after PRs #65, #68, #69. Marks were rendered, but ~5000px off-screen to the left.

## Fix
Collapse the four conditional branches in \`renderMark\` into a single returned \`<div>\` with a computed className. props (\`{...props}\`) now spread onto the actual outermost element so react-range's ref attaches reliably. Same logic preserved:

- \`!isRange && !cumulative\`: plain \`SliderTick\`
- \`!isRange && cumulative\`: \`SliderTick\` + \`selected\` when value ≤ thumb
- \`isRange\`: \`SliderTick\` + \`selected\` when value falls inside the range

Also drops the now-unneeded \`cloneElement\` wrappers in \`renderTrack\` — children come back from react-range with proper keys on the div, no manipulation needed.

## Test plan
- [ ] In dev, switch Residents → Abnormality (and other combinations) — slider ticks visible, dates visible, no -5000px shenanigans in the DOM.
- [ ] Drag the thumb — onChange still fires, thumb moves correctly.
- [ ] Range slider (in Menu under Data parameters) still renders ticks correctly.
- [ ] Other sliders that use FMSlider (spatial/temporal resolution in Menu) still work.