### PR TITLE
Force slider remeasure once container has real width

### DIFF
--- a/src/components/FMSlider/FMSlider.js
+++ b/src/components/FMSlider/FMSlider.js
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import styles from "./FMSlider.module.css"
 import { Range } from "react-range"
 import { getTrackBackground } from "react-range/lib/utils"
@@ -20,6 +20,28 @@ const FMSlider = ({
 }) => {
     values = values || (isRange ? [min, max] : [min])
 
+    // react-range measures the track once on mount via the ref'd inner div.
+    // When the slider remounts inside a flex parent on indicator switch, that
+    // measurement can run before layout settles — track gets measured as 0 and
+    // every mark ends up at left:-1px until something (window resize, devtools
+    // opening) makes react-range recompute. ResizeObserver lets us detect when
+    // the container actually has a width and trigger react-range's own resize
+    // handler to remeasure.
+    const containerRef = useRef(null)
+    useEffect(() => {
+        if (!containerRef.current || typeof ResizeObserver === "undefined") return
+        let lastWidth = 0
+        const obs = new ResizeObserver(entries => {
+            const w = entries[0].contentRect.width
+            if (w > 0 && w !== lastWidth) {
+                lastWidth = w
+                window.dispatchEvent(new Event("resize"))
+            }
+        })
+        obs.observe(containerRef.current)
+        return () => obs.disconnect()
+    }, [])
+
     const getLabelForIndex = index => {
         if (labels === undefined) {
             return step * index + min
@@ -33,6 +55,7 @@ const FMSlider = ({
 
     return (
         <div
+            ref={containerRef}
             className={`${styles.FMSlider}${isRange ? ` ${styles.Range}` : ""}${
                 outerLabelsOnly ? ` ${styles.outerLabelsOnly}` : ""
             }`}


### PR DESCRIPTION
## Summary
- Adds a ResizeObserver in `FMSlider` that detects when the container has settled to its real width and dispatches a `window.resize` event, triggering react-range's own resize handler to recompute mark positions.
- Fixes the residual case from PR #70: marks would still pile up at `left:-1px` when the slider mounts inside a flex parent before layout has settled (which happens on indicator switch — `CurrentTimeUnitSlider` conditionally remounts the slider, so it gets a fresh `componentDidMount` against an unsized track).

## Why this exists
PR #70 fixed the `-4999px` positions (caused by null markRefs from a Fragment wrapper). But a separate, milder symptom remained: when react-range runs `calculateMarkOffsets` on mount, it measures the ref'd inner track div via `getBoundingClientRect`. If that div's parent flex container hasn't been laid out yet, `trackWidth` is 0 and every mark ends up at `(0/N)*i - markWidth/2 = -1px`.

User confirmed the smoking gun by inspecting a tick: `style="position: absolute; left: -1px; margin-top: -2px;"` — and confirmed that opening devtools (which fires a window resize) fixes it.

## What this changes
- Adds `useRef` + `useEffect` setting up a ResizeObserver on the outer FMSlider container.
- On the first non-zero width (and any subsequent width change), dispatches `new Event("resize")` so react-range remeasures via its own listener.
- Guarded against `typeof ResizeObserver === "undefined"` (JSDOM in tests).
- Only re-dispatches when width actually changes, so we don't loop with our own dispatched event.

## Test plan
- [ ] CI green
- [ ] Merge → wait for dev deploy
- [ ] Hard-refresh dev dashboard
- [ ] Switch between indicators in Residents category — ticks/labels should render at correct positions every time, without needing to open devtools
- [ ] Inspect a tick: `left` should be a proper computed offset (e.g. `left: 17px` for the second tick), not `-1px`