### PR TITLE
Force slider remount on indicator switch (workaround react-range update-path bug)

### DIFF
--- a/src/components/FMSlider/FMSlider.js
+++ b/src/components/FMSlider/FMSlider.js
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import React, { useEffect, useRef } from "react"
+import React from "react"
 import styles from "./FMSlider.module.css"
 import { Range } from "react-range"
 import { getTrackBackground } from "react-range/lib/utils"
@@ -20,28 +20,6 @@ const FMSlider = ({
 }) => {
     values = values || (isRange ? [min, max] : [min])
 
-    // react-range measures the track once on mount via the ref'd inner div.
-    // When the slider remounts inside a flex parent on indicator switch, that
-    // measurement can run before layout settles — track gets measured as 0 and
-    // every mark ends up at left:-1px until something (window resize, devtools
-    // opening) makes react-range recompute. ResizeObserver lets us detect when
-    // the container actually has a width and trigger react-range's own resize
-    // handler to remeasure.
-    const containerRef = useRef(null)
-    useEffect(() => {
-        if (!containerRef.current || typeof ResizeObserver === "undefined") return
-        let lastWidth = 0
-        const obs = new ResizeObserver(entries => {
-            const w = entries[0].contentRect.width
-            if (w > 0 && w !== lastWidth) {
-                lastWidth = w
-                window.dispatchEvent(new Event("resize"))
-            }
-        })
-        obs.observe(containerRef.current)
-        return () => obs.disconnect()
-    }, [])
-
     const getLabelForIndex = index => {
         if (labels === undefined) {
             return step * index + min
@@ -55,7 +33,6 @@ const FMSlider = ({
 
     return (
         <div
-            ref={containerRef}
             className={`${styles.FMSlider}${isRange ? ` ${styles.Range}` : ""}${
                 outerLabelsOnly ? ` ${styles.outerLabelsOnly}` : ""
             }`}

--- a/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
+++ b/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
@@ -169,6 +169,16 @@ const CurrentTimeUnitSlider = () => {
         <div className={styles.CurrentTimeUnitSlider} data-testid="CurrentTimeUnitSlider">
             {currentAvailableTimeRange && selectedTimeRangeForCurrentData && (
                 <FMSlider
+                    // force a fresh mount on indicator switch. react-range
+                    // 1.8.14's componentDidUpdate has a bug: when min/max/step
+                    // change, it rebuilds markRefs with fresh createRef objects
+                    // and calls calculateMarkOffsets in the same tick — before
+                    // those new refs are attached to the DOM. That gives every
+                    // mark a -4999px position via the markWidth=9999 fallback,
+                    // and the offsets are never recalculated once the refs do
+                    // attach. Forcing remount via key sidesteps the update path
+                    // entirely (componentDidMount runs against attached refs).
+                    key={currentIndicator?.indicator_id}
                     values={selectedTimeEntity}
                     outerLabelsOnly={true}
                     step={1}


### PR DESCRIPTION
## Summary
- Adds `key={currentIndicator?.indicator_id}` to FMSlider in `CurrentTimeUnitSlider` so it remounts cleanly on every indicator switch.
- Reverts PR #71's ResizeObserver/window-resize-dispatch — it was based on a wrong theory and is a no-op in practice (see below).

## Root cause
Bug is actually in react-range 1.8.14 itself, in `Range.js` `componentDidUpdate`:

```js
if (prevProps.max !== max || prevProps.min !== min || prevProps.step !== step) {
    this.updateMarkRefs(this.props);    // creates fresh createRef() objects
}
...
if (prevProps.max !== max || prevProps.min !== min || prevProps.step !== step ||
    prevState.markOffsets.length !== this.state.markOffsets.length) {
    this.calculateMarkOffsets();         // reads markRefs[i].current
}
```

When min/max/step change on indicator switch:
1. `updateMarkRefs` rebuilds `this.markRefs` with brand-new `createRef()` objects. None of them are attached to DOM yet — the existing marks still have the *old* refs.
2. `calculateMarkOffsets` is called in the same tick. It reads `markRefs[i].current` — all `null`. Falls back to the `markHeight = markWidth = 9999` defaults defined at `Range.js:431-432`, computes `(trackWidth/N)*i + paddingLeft - 9999/2 ≈ -4999`, and persists those broken offsets via `setState({ markOffsets: [...] })`.
3. The subsequent re-render renders the marks with the new ref objects in JSX and React attaches them on commit. `componentDidUpdate` fires again, but its gate (`prevProps.max !== max || ... || prevState.markOffsets.length !== this.state.markOffsets.length`) is now false (props are stable, length didn't change), so `calculateMarkOffsets` is never called against the now-attached refs.

The slider stays at -4999 until something external pokes it.

## Why category switch already works
`{currentAvailableTimeRange && <FMSlider />}` in `CurrentTimeUnitSlider`. On category change, `currentAvailableTimeRange` briefly becomes undefined while loading the new category's data, so FMSlider unmounts and remounts — fresh `componentDidMount`, no broken-update path.

Indicator switch within the same category keeps `currentAvailableTimeRange` defined and just changes props on the existing FMSlider, hitting the broken update path.

## Why programmatic `window.dispatchEvent('resize')` doesn't fix it but manual resize does
react-range 1.8.14 uses a `ResizeObserver` on the *track element*, not a window resize listener. Manual window resize causes the track's actual pixel width to change → ResizeObserver fires → `onResize` → `calculateMarkOffsets` runs against now-attached refs → correct positions. Programmatic `dispatchEvent` on `window` reaches no listener inside react-range.

This also means PR #71's mechanism (dispatching window resize from a ResizeObserver on FMSlider's container) was a no-op — reverted here.

## Workaround
Pass `key={currentIndicator?.indicator_id}` so React remounts FMSlider on every indicator change. Same effect as the category switch path that already works.

## Test plan
- [ ] CI green
- [ ] Merge → wait for dev deploy (~15-30 min)
- [ ] Hard-refresh dev dashboard
- [ ] Switch indicators within Residents category — labels and ticks should render correctly every time
- [ ] Inspect a tick after indicator switch — `left` should be a positive offset, not `-4999`
- [ ] Switch categories — should still work as before