### PR TITLE
Key slider on time range tuple (PR #72 fixed the wrong moment)

### DIFF
--- a/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
+++ b/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
@@ -169,16 +169,18 @@ const CurrentTimeUnitSlider = () => {
         <div className={styles.CurrentTimeUnitSlider} data-testid="CurrentTimeUnitSlider">
             {currentAvailableTimeRange && selectedTimeRangeForCurrentData && (
                 <FMSlider
-                    // force a fresh mount on indicator switch. react-range
+                    // force a fresh mount whenever min/max change. react-range
                     // 1.8.14's componentDidUpdate has a bug: when min/max/step
                     // change, it rebuilds markRefs with fresh createRef objects
                     // and calls calculateMarkOffsets in the same tick — before
                     // those new refs are attached to the DOM. That gives every
                     // mark a -4999px position via the markWidth=9999 fallback,
                     // and the offsets are never recalculated once the refs do
-                    // attach. Forcing remount via key sidesteps the update path
-                    // entirely (componentDidMount runs against attached refs).
-                    key={currentIndicator?.indicator_id}
+                    // attach. Key on the time range (which is what feeds min/max)
+                    // so any min/max change triggers a remount instead of the
+                    // broken update path — componentDidMount runs against
+                    // attached refs and gets correct offsets.
+                    key={`${selectedTimeRangeForCurrentData[0]}-${selectedTimeRangeForCurrentData[1]}`}
                     values={selectedTimeEntity}
                     outerLabelsOnly={true}
                     step={1}


### PR DESCRIPTION
## Summary
PR #72's `key={currentIndicator?.indicator_id}` forced a remount on indicator switch but at the wrong moment — the time range data (which is what actually drives `min`/`max` and triggers react-range's broken update path) updates asynchronously *after* the indicator changes. Re-keying on the time range itself fixes both cases.

## Why PR #72 wasn't enough
`Dashboard.js:417,433` shows the time range is dispatched after an `api.timerange` call that's triggered by the indicator change. So on indicator switch:

1. `dispatch(setCurrentIndicator(new))` → PR #72's key changes → FMSlider remounts cleanly with the **old** time range (slider looks fine)
2. `api.timerange` returns → `dispatch(setSelectedTimeRangeForCurrentData(new))` → FMSlider re-renders with new `min`/`max`, but the key is unchanged → react-range's broken `componentDidUpdate` path runs → -4999

This also explains why the user observed indicator switch sometimes fixed and sometimes broke the slider — it depended on whether the new indicator happened to have the same time range as the previous one. Same min/max meant no update-path trigger and the slider stayed correct; different min/max meant -4999.

Category switch keeps working because `Dashboard.js:264` dispatches `setSelectedTimeRangeForCurrentData(undefined)` early, which makes the conditional render fully unmount FMSlider until all the new state is in place.

## Fix
Key on the time range tuple itself, which is what actually drives `min`/`max`:

```jsx
key={`${selectedTimeRangeForCurrentData[0]}-${selectedTimeRangeForCurrentData[1]}`}
```

Any change to `min` or `max` now forces a remount, sidestepping react-range's broken update path entirely. `componentDidMount` runs against attached refs and gets correct offsets.

## Test plan
- [ ] CI green
- [ ] Merge → wait for dev deploy
- [ ] Hard-refresh dev
- [ ] Switch between indicators with **different** time ranges → labels and ticks correct every time
- [ ] Switch between indicators with the **same** time range (if any) → also correct (no remount needed)
- [ ] Switch category → still works
- [ ] Inspect a tick after any switch → real positive offset, not -4999