### PR TITLE
Clamp slider values to [min, max] to avoid checkBoundaries throw on remount

### DIFF
--- a/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
+++ b/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
@@ -181,7 +181,20 @@ const CurrentTimeUnitSlider = () => {
                     // broken update path — componentDidMount runs against
                     // attached refs and gets correct offsets.
                     key={`${selectedTimeRangeForCurrentData[0]}-${selectedTimeRangeForCurrentData[1]}`}
-                    values={selectedTimeEntity}
+                    // clamp values to [min, max]. After a remount triggered by
+                    // a new time range, selectedTimeEntity (from redux) is
+                    // briefly the previous indicator's value, which can fall
+                    // outside the new range. The effect on line 51 dispatches
+                    // a corrected entity but only on the next render, and
+                    // react-range's componentDidMount calls checkBoundaries
+                    // synchronously and throws RangeError if value<min — which
+                    // blanks the whole dashboard.
+                    values={[
+                        Math.min(
+                            Math.max(selectedTimeEntity?.[0] ?? selectedTimeRangeForCurrentData[0], selectedTimeRangeForCurrentData[0]),
+                            selectedTimeRangeForCurrentData[1]
+                        )
+                    ]}
                     outerLabelsOnly={true}
                     step={1}
                     min={selectedTimeRangeForCurrentData[0]}


### PR DESCRIPTION
## Summary
PR #73's key-on-time-range fix DID work — slider remounted cleanly on time-range change and rendered correct tick positions (user confirmed: "Abnormality Score worked for the first time"). But the remount exposed a different race that pre-fix code didn't hit: react-range's `componentDidMount` calls `checkBoundaries` synchronously and throws `RangeError` if `value < min`.

When user switches indicator, redux's `selectedTimeEntity` is briefly the previous indicator's value (e.g. `[59]`) while the new `selectedTimeRangeForCurrentData` is `[62, 73]`. Pre-PR #73 this was silent (no remount → no checkBoundaries call → just a wrong-position thumb until the existing effect corrected `selectedTimeEntity` on the next render). Post-PR #73 the remount triggers `checkBoundaries` which throws — and the React tree blanks.

User's symptom: `RangeError: value (59) is smaller than min (62)` from `utils.js:76`, completely blank screen.

## Why the existing effect isn't enough
`CurrentTimeUnitSlider.js:51-97` dispatches a corrected `selectedTimeEntity` when `selectedTimeRangeForCurrentData` changes. But that's a `useEffect` running *after* render — by the time the effect fires, the slider has already mounted, called `checkBoundaries`, and thrown.

## Fix
Clamp the value at the JSX site before passing it to FMSlider:

```jsx
values={[
    Math.min(
        Math.max(selectedTimeEntity?.[0] ?? selectedTimeRangeForCurrentData[0], selectedTimeRangeForCurrentData[0]),
        selectedTimeRangeForCurrentData[1]
    )
]}
```

- When `selectedTimeEntity[0]` is in `[min, max]` → no-op
- When stale (below min or above max) → clamps to min or max
- When undefined → falls back to min
- react-range never sees an out-of-range value, so checkBoundaries doesn't throw

The existing effect still runs and corrects redux state to `[min]` on the next render, by which time my clamp is a no-op against the same value. No visible flicker.

## Test plan
- [ ] CI green
- [ ] Merge → wait for dev deploy
- [ ] Hard-refresh dev
- [ ] Reproduce previous crash: pick Residents → switch to Abnormality Score → switch again → should NOT blank
- [ ] All ticks should be at correct positions throughout
- [ ] Slider drag should still work (onChange returns in-range values which the clamp passes through)