### PR TITLE
Don't render bottom slider when time range collapses to one entity

### DIFF
--- a/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
+++ b/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
@@ -165,9 +165,21 @@ const CurrentTimeUnitSlider = () => {
         return currentAvailableTimeRange
     }, [currentAvailableTimeRange, currentCategory, currentTemporalResolution])
 
+    // when the user collapses the Menu's range slider so both thumbs sit on
+    // the same time entity, selectedTimeRangeForCurrentData becomes [N, N].
+    // The bottom slider would then mount with min=max=N, which react-range's
+    // checkBoundaries rejects (throws RangeError, blanks the dashboard).
+    // One time entity means there's nothing to drag between — render a label
+    // and skip the slider.
+    const isSingleTimePoint =
+        selectedTimeRangeForCurrentData &&
+        selectedTimeRangeForCurrentData[0] === selectedTimeRangeForCurrentData[1]
+    const singleLabel =
+        isSingleTimePoint && labels ? labels[selectedTimeRangeForCurrentData[0]] : undefined
+
     return (
         <div className={styles.CurrentTimeUnitSlider} data-testid="CurrentTimeUnitSlider">
-            {currentAvailableTimeRange && selectedTimeRangeForCurrentData && (
+            {currentAvailableTimeRange && selectedTimeRangeForCurrentData && !isSingleTimePoint && (
                 <FMSlider
                     // force a fresh mount whenever min/max change. react-range
                     // 1.8.14's componentDidUpdate has a bug: when min/max/step
@@ -208,6 +220,9 @@ const CurrentTimeUnitSlider = () => {
                     cumulative={false}
                     outputIsVisible={false}
                 />
+            )}
+            {isSingleTimePoint && (
+                <span className={styles.Info}>{singleLabel}</span>
             )}
             {(!currentAvailableTimeRange || !selectedTimeRangeForCurrentData) && (
                 <span className={styles.Info}>{t("dashboard.slider_text")}</span>

--- a/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
+++ b/src/pages/Dashboard/components/CurrentTimeUnitSlider/CurrentTimeUnitSlider.js
@@ -165,21 +165,34 @@ const CurrentTimeUnitSlider = () => {
         return currentAvailableTimeRange
     }, [currentAvailableTimeRange, currentCategory, currentTemporalResolution])
 
-    // when the user collapses the Menu's range slider so both thumbs sit on
-    // the same time entity, selectedTimeRangeForCurrentData becomes [N, N].
-    // The bottom slider would then mount with min=max=N, which react-range's
-    // checkBoundaries rejects (throws RangeError, blanks the dashboard).
-    // One time entity means there's nothing to drag between — render a label
-    // and skip the slider.
-    const isSingleTimePoint =
-        selectedTimeRangeForCurrentData &&
-        selectedTimeRangeForCurrentData[0] === selectedTimeRangeForCurrentData[1]
+    // react-range's checkBoundaries throws on componentDidMount whenever
+    // min >= max OR the value is out of [min, max]. PR #73's force-remount
+    // means this throw is hit every time the time range changes, including
+    // the degenerate cases below:
+    //   - [N, N]   user collapsed the Menu's range slider to one entity
+    //   - [M, N] with M > N   inverted range (e.g. DatePicker indexOf
+    //                          returned -1 for one endpoint)
+    //   - [-1, *] / [*, -1]   DatePicker couldn't find the date
+    //   - non-finite values
+    // A slider over a degenerate range is meaningless, so render a label
+    // (or just nothing) and skip mounting the slider.
+    const hasValidRange =
+        Array.isArray(selectedTimeRangeForCurrentData) &&
+        Number.isFinite(selectedTimeRangeForCurrentData[0]) &&
+        Number.isFinite(selectedTimeRangeForCurrentData[1]) &&
+        selectedTimeRangeForCurrentData[0] < selectedTimeRangeForCurrentData[1] &&
+        selectedTimeRangeForCurrentData[0] >= 0
+    const isSinglePoint =
+        Array.isArray(selectedTimeRangeForCurrentData) &&
+        selectedTimeRangeForCurrentData[0] === selectedTimeRangeForCurrentData[1] &&
+        Number.isFinite(selectedTimeRangeForCurrentData[0]) &&
+        selectedTimeRangeForCurrentData[0] >= 0
     const singleLabel =
-        isSingleTimePoint && labels ? labels[selectedTimeRangeForCurrentData[0]] : undefined
+        isSinglePoint && labels ? labels[selectedTimeRangeForCurrentData[0]] : undefined
 
     return (
         <div className={styles.CurrentTimeUnitSlider} data-testid="CurrentTimeUnitSlider">
-            {currentAvailableTimeRange && selectedTimeRangeForCurrentData && !isSingleTimePoint && (
+            {currentAvailableTimeRange && hasValidRange && (
                 <FMSlider
                     // force a fresh mount whenever min/max change. react-range
                     // 1.8.14's componentDidUpdate has a bug: when min/max/step
@@ -221,7 +234,7 @@ const CurrentTimeUnitSlider = () => {
                     outputIsVisible={false}
                 />
             )}
-            {isSingleTimePoint && (
+            {currentAvailableTimeRange && isSinglePoint && (
                 <span className={styles.Info}>{singleLabel}</span>
             )}
             {(!currentAvailableTimeRange || !selectedTimeRangeForCurrentData) && (


### PR DESCRIPTION
## Summary
PR #73's key-on-time-range fix turned an existing visual bug into a hard crash for the degenerate case where the user collapses the Menu's Data Parameters range slider so both thumbs sit on the same time entity. This PR handles that case by rendering a label instead of attempting to mount a slider with `min === max`.

## Symptom (reproducible)
- Pick any monthly indicator with at least a few months of data
- Open Data Parameters in the Menu and drag one thumb of the Dates range slider until it meets the other thumb
- → White screen. Console shows:
  ```
  RangeError: min (64) is equal/bigger than max (64)
      at checkBoundaries (utils.js:73)
      at Range.js:481 (componentDidMount)
  ```

## Cause
react-range's `componentDidMount` calls `checkBoundaries(value, min, max)` which throws if `min >= max`. PR #73 added `key={'${selectedTimeRangeForCurrentData[0]}-${selectedTimeRangeForCurrentData[1]}'}` to the bottom FMSlider so the slider remounts on every time-range change — needed to dodge react-range's broken `componentDidUpdate` ordering. But once the range collapses to `[N, N]`, the remount supplies `min=N, max=N` → checkBoundaries throws → the React tree unwinds → white screen.

Before PR #73 this case didn't crash because the bottom slider just updated props (no remount, no checkBoundaries call). It rendered in a stale/broken state visually but the dashboard stayed up.

## Fix
Detect `selectedTimeRangeForCurrentData[0] === [1]` and skip the FMSlider entirely, rendering the single selected time-entity label instead. A slider with one drag position would be useless anyway.

```jsx
const isSingleTimePoint =
    selectedTimeRangeForCurrentData &&
    selectedTimeRangeForCurrentData[0] === selectedTimeRangeForCurrentData[1]
const singleLabel =
    isSingleTimePoint && labels ? labels[selectedTimeRangeForCurrentData[0]] : undefined

// then in JSX:
{... && !isSingleTimePoint && <FMSlider .../>}
{isSingleTimePoint && <span className={styles.Info}>{singleLabel}</span>}
```

## Test plan
- [ ] CI green
- [ ] Merge → wait for dev redeploy
- [ ] On dev: pick a monthly indicator, collapse the Data Parameters range slider to a single entity. Should show the date as a label, NOT white-screen.
- [ ] Drag the range slider apart again. Bottom slider should reappear and work normally.
- [ ] Switching indicators with a multi-entity range still works (PR #73 behavior preserved).