### PR TITLE
Reject crossed thumbs in Menu range slider

### DIFF
--- a/src/pages/Dashboard/components/Menu/Menu.js
+++ b/src/pages/Dashboard/components/Menu/Menu.js
@@ -305,7 +305,16 @@ const Menu = ({ collapsed = false }) => {
                                                     min={0}
                                                     max={currentAvailableTimeRange?.length - 1}
                                                     onChange={values => {
-                                                        dispatch(setSelectedTimeRangeForCurrentData(values))
+                                                        // reject crossed thumbs (values[0] > values[1]).
+                                                        // react-range with allowOverlap=true lets thumbs
+                                                        // cross, dispatching an inverted range that the
+                                                        // bottom CurrentTimeUnitSlider can't render. By
+                                                        // ignoring the dispatch we keep redux at the last
+                                                        // valid range; the controlled `values` prop will
+                                                        // snap the visual thumbs back on next render.
+                                                        if (values[0] <= values[1]) {
+                                                            dispatch(setSelectedTimeRangeForCurrentData(values))
+                                                        }
                                                     }}
                                                     labels={timeLabels}
                                                     isRange={true}


### PR DESCRIPTION
## Summary
Tiny one-line behavioural fix: in the Menu's Data Parameters range slider, ignore the `onChange` dispatch when the user crosses the two thumbs. Pairs with PR #75 which handles the single-date case.

## Symptom
react-range with `allowOverlap=true` (which `FMSlider` sets) lets the two thumbs of a range slider cross through each other. When you drag the end thumb past the begin thumb, react-range dispatches a crossed range like `[10, 5]`. After PR #75 hardening, the bottom slider rejects this state (neither valid range nor single point) so the bottom slider area goes blank, while the menu's thumbs visibly stay crossed.

## Fix
One-line guard in `Menu.js` `onChange`:

```js
if (values[0] <= values[1]) {
    dispatch(setSelectedTimeRangeForCurrentData(values))
}
```

When the user tries to cross thumbs, the dispatch is rejected → redux stays at the last valid range → react-range's controlled `values` prop reverts the visual thumbs on the next render. UX result: the end thumb can't be dragged past the begin thumb.

The `[N, N]` collapse case still dispatches (because `N <= N`), so PR #75's single-date label flow still works.

## Test plan
- [ ] CI green
- [ ] Merge → wait for dev redeploy
- [ ] Try dragging the Menu range slider's end thumb past the begin thumb. Thumb should not cross.
- [ ] Try dragging it onto the begin thumb. Bottom slider should show single date label (PR #75 behavior preserved).
- [ ] Normal range adjustments still work.